### PR TITLE
When targeting es2020 an import error is reported

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jetblack/date",
   "private": false,
-  "version": "2.12.1",
+  "version": "2.12.2",
   "description": "Date utilities",
   "keywords": [
     "date",


### PR DESCRIPTION
This seems to be something to do with the lexical order of static methods and is specific to their use in the constructor.

Rather than re-order the methods (which seemed a little fragile) we decided to pull the static methods out as unexported functions.